### PR TITLE
Make source a bit more compatible with Eclipse DLTK for Ruby.

### DIFF
--- a/lib/kaitai/struct/visualizer/hex_viewer.rb
+++ b/lib/kaitai/struct/visualizer/hex_viewer.rb
@@ -10,7 +10,7 @@ class HexViewer
     @shift_x = 0
     @tree = tree
 
-    @embedded = not(tree.nil?)
+    @embedded = !(tree.nil?)
     @max_scr_ln = @ui.rows - 3
 
     @addr = 0

--- a/lib/kaitai/struct/visualizer/ksy_compiler.rb
+++ b/lib/kaitai/struct/visualizer/ksy_compiler.rb
@@ -17,7 +17,7 @@ class KSYCompiler
     errs = false
     main_class_name = nil
     Dir.mktmpdir { |code_dir|
-      args = ['--ksc-json-output', '--debug', '-t', 'ruby', *fns, '-d', code_dir]
+      args = ['--ksc-json-output', '--debug', '-t', 'ruby', '-d', code_dir, *fns]
 
       # Extra arguments
       extra = []


### PR DESCRIPTION
There's a Ruby-plugin for Eclipse based on the project Eclipse DLTK and that errors out with syntax errors at two places. Both ist most likely wrong by the plugin and searching the web others report similar issues, but as the changes are minor, I would like to suggest changing both statements.