### PR TITLE
Allow "ksv" to use pre-compiled Ruby-files instead of compiling itself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ out source code in repository:
 
 ## Usage
 
-`ksv <binary-file> <ksy-file>...`
+`ksv <binary-file> <ksy-file>...|<rb-file>`
 
 ## Licensing
 

--- a/bin/ksv
+++ b/bin/ksv
@@ -17,7 +17,7 @@ require 'kaitai/struct/visualizer'
 
 options = {}
 parser = OptionParser.new do |opts|
-  opts.banner = "Usage: #{File.basename($PROGRAM_NAME)} [options] <file_to_parse.bin> <format.ksy>..."
+  opts.banner = "Usage: #{File.basename($PROGRAM_NAME)} [options] <file_to_parse.bin> <format.ksy>...|<format.rb>"
   opts.separator ""
 
   opts.on("-I", "--import-path [DIRECTORIES]", ".ksy library search path(s) for imports (see also KSPATH env variable)") do |v|

--- a/lib/kaitai/struct/visualizer/ksy_compiler.rb
+++ b/lib/kaitai/struct/visualizer/ksy_compiler.rb
@@ -13,6 +13,24 @@ class KSYCompiler
     @out = out
   end
 
+  def compile_formats_if(fns)
+    if (fns.length > 1) || fns[0].end_with?('.ksy')
+      return compile_formats(fns)
+    end
+
+    fname = File.basename(fns[0], '.rb')
+    dname = File.dirname( fns[0])
+    gpath = File.expand_path('*.rb', dname)
+
+    Dir.glob(gpath) { |fname|
+      @out.puts "Loading: #{fname}"
+      require File.expand_path(fname, dname)
+    }
+
+    # The name of the main class is that of the given file by convention.
+    return fname.split('_').map(&:capitalize).join()
+  end
+
   def compile_formats(fns)
     errs = false
     main_class_name = nil
@@ -95,7 +113,6 @@ class KSYCompiler
           end
         end
       }
-
     }
 
     if errs

--- a/lib/kaitai/struct/visualizer/parser.rb
+++ b/lib/kaitai/struct/visualizer/parser.rb
@@ -22,7 +22,7 @@ class Parser
   end
 
   def load
-    main_class_name = @compiler.compile_formats(@formats_fn)
+    main_class_name = @compiler.compile_formats_if(@formats_fn)
 
     main_class = Kernel::const_get(main_class_name)
     @data = main_class.from_file(@bin_fn)


### PR DESCRIPTION
If one runs into problems with the compiled KSY and things break because bugs/missing implementation in the compiler most likely, sometimes it's easier to change formerly generated Ruby to test which changes lead to successful Ruby and afterwards change the compiler accordingly. With the former behaviour of "ksv" compiling always using temporary directories, this was pretty much impossible to achieve and one needed to change the compiler always to generate new code. But for people new to Scala and Ruby (like me) this is a pretty difficult roundtrip.

So "ksv" has been enhanced so that some pre-compiled Ruby file can be given instead of some KSY and "ksv" doesn't compile in that case anymore. Instead, by convention all Ruby files in the parent dir of the given file are required and the given file name is used as main class. Both approaches are pretty much what "ksv" implemented currently anyway.

This helped me debugging https://github.com/kaitai-io/kaitai_struct/issues/552.