### PR TITLE
Open3.popen3 deadlocks in case of too much output to std*.

### DIFF
--- a/lib/kaitai/struct/visualizer/ksy_compiler.rb
+++ b/lib/kaitai/struct/visualizer/ksy_compiler.rb
@@ -33,15 +33,7 @@ class KSYCompiler
       # on Windows.
       args.unshift('--') unless Kaitai::TUI::is_windows?
 
-      status = nil
-      log_str = nil
-      err_str = nil
-      Open3.popen3('kaitai-struct-compiler', *args) { |stdin, stdout, stderr, wait_thr|
-        status = wait_thr.value
-        log_str = stdout.read
-        err_str = stderr.read
-      }
-
+      log_str, err_str, status = Open3.capture3('kaitai-struct-compiler', *args)
       if not status.success?
         if status.exitstatus == 127
           @out.puts "ksv: unable to find and execute kaitai-struct-compiler in your PATH"


### PR DESCRIPTION
In the past, "ksv" didn't start properly and hanged sometimes, making it
necessary to restart the app a few times to get things working. Now this
didn't help anymore and the reason was too many debugging output
generated by "ksc" because of some forgotten "println"-statements. The
official docs suggest that on too many data especially on STDERR things
deadlock unless pipes are read in parallel and that capture3 should be
used instead.

As the former implementation simply blocked as well, there shouldn't be
any downside to switching to capture3. This solved the hanging app for
me and printed a JSON parse error, which made me recognize the forgotten
"println".

https://www.rubydoc.info/stdlib/open3/Open3#popen3-class_method