### PR TITLE
PoC for resizing the Windows console depending on pressed keys.

### DIFF
--- a/lib/kaitai/console_ansi.rb
+++ b/lib/kaitai/console_ansi.rb
@@ -21,7 +21,7 @@ class ConsoleANSI
 
     Signal.trap('SIGWINCH', proc {
       get_term_size
-      @on_resize.call if @on_resize
+      @on_resize.call(true) if @on_resize
     })
   end
 

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -144,7 +144,7 @@ class ConsoleWindows
 
     # https://github.com/kaitai-io/kaitai_struct_visualizer/issues/14
     get_term_size
-    @on_resize.call if @on_resize
+    @on_resize.call(false) if @on_resize
 
     return input
   end

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -142,6 +142,7 @@ class ConsoleWindows
       input << GETCH.call.chr
     end
 
+    # https://github.com/kaitai-io/kaitai_struct_visualizer/issues/14
     get_term_size
     @on_resize.call if @on_resize
 

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -35,9 +35,13 @@ class ConsoleWindows
     # } CONSOLE_SCREEN_BUFFER_INFO;
 
     # 4 + 4 + 2 + 4 * 2 + 4 = 22
-       
+
+    get_term_size
+  end
+
+  def get_term_size
     csbi = 'X' * 22
-    
+
     GET_CONSOLE_SCREEN_BUFFER_INFO.call(@stdout_handle, csbi)
     @buf_cols, @buf_rows,
       cur_x, cur_y, cur_attr,
@@ -60,7 +64,7 @@ class ConsoleWindows
 #    reserved = 'XXXX'
 #    WRITE_CONSOLE.call(@stdout_handle, s, s.length, num_written, reserved)
   end
-  
+
   def clear
     con_size = @buf_cols * @buf_rows
     num_written = 'XXXX'
@@ -130,13 +134,17 @@ class ConsoleWindows
 
   ZERO_ESCAPE = 0.chr
   E0_ESCAPE = 0xe0.chr
-  
+
   # Reads keypresses from the user including 2 and 3 escape character sequences.
   def read_char
     input = GETCH.call.chr
     if input == E0_ESCAPE || input == ZERO_ESCAPE
       input << GETCH.call.chr
     end
+
+    get_term_size
+    @on_resize.call if @on_resize
+
     return input
   end
 
@@ -248,7 +256,7 @@ class ConsoleWindows
   def current_color_code
     (@bg_color << 4) | @fg_color
   end
-  
+
   def update_colors
     SET_CONSOLE_TEXT_ATTRIBUTE.call(@stdout_handle, current_color_code)
   end

--- a/lib/kaitai/struct/visualizer/tree.rb
+++ b/lib/kaitai/struct/visualizer/tree.rb
@@ -22,10 +22,10 @@ class Tree
     @cur_shift = 0
     @do_exit = false
 
-    @ui.on_resize = proc {
+    @ui.on_resize = proc {|redraw_needed|
       recalc_sizes
-      redraw
-      @hv.redraw
+      redraw      if redraw_needed
+      @hv.redraw  if redraw_needed
     }
   end
 


### PR DESCRIPTION
This somewhat allows to make long instance names etc. better readable including their values without the need to change how names and values are printed. Individual parts a re printed directly to the console by nodes, making it difficult to properly reduce each sizes according the available space and such. Misusing key events might be the easier solution.

This fixes https://github.com/kaitai-io/kaitai_struct_visualizer/issues/14.