### PR TITLE
Using :Fixnum and :Bignum is deprecated.

### DIFF
--- a/lib/kaitai/struct/visualizer/node.rb
+++ b/lib/kaitai/struct/visualizer/node.rb
@@ -40,9 +40,8 @@ class Node
 
   def openable?
     not (
-      @value.is_a?(Fixnum) or
-      @value.is_a?(Bignum) or
       @value.is_a?(Float) or
+      @value.is_a?(Integer) or
       @value.is_a?(String) or
       @value.is_a?(Symbol) or
       @value === true or
@@ -88,7 +87,7 @@ class Node
     pos = 2 * level + 4 + @id.length
 
     if open? or not openable?
-      if @value.is_a?(Fixnum) or @value.is_a?(Bignum) or @value.is_a?(Float)
+      if @value.is_a?(Float) or @value.is_a?(Integer)
         print " = #{@value}"
       elsif @value.is_a?(Symbol)
         print " = #{@value}"
@@ -173,9 +172,8 @@ class Node
 
     @explored = true
 
-    if @value.is_a?(Fixnum) or
-       @value.is_a?(Bignum) or
-       @value.is_a?(Float) or
+    if @value.is_a?(Float) or
+       @value.is_a?(Integer) or
        @value.is_a?(String) or
        @value == true or
        @value == false or

--- a/lib/kaitai/struct/visualizer/tree.rb
+++ b/lib/kaitai/struct/visualizer/tree.rb
@@ -237,7 +237,7 @@ class Tree
 
   def self.explore_object(obj, level)
     root = Node.new(obj, level)
-    if obj.is_a?(Fixnum) or obj.is_a?(String)
+    if obj.is_a?(Integer) or obj.is_a?(String)
       # do nothing else
     elsif obj.is_a?(Array)
       root = Node.new(obj, level)


### PR DESCRIPTION
Using :Fixnum and :Bignum is [deprecated](https://bugs.ruby-lang.org/issues/12005) and leads to an ugly warning when viewing data. Things are not aligned properly anymore and can only
be cleared by using the arrow keys.

![Clipboard01](https://user-images.githubusercontent.com/6223655/75148177-4a372a80-56ff-11ea-9354-ed4c0c1ff754.png)
