### PR TITLE
Dockerize `ksv`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby
+
+COPY . /app
+WORKDIR /app
+
+RUN gem build -o ksv.gem kaitai-struct-visualizer \
+      && gem install ksv.gem
+
+ENTRYPOINT ["/usr/local/bundle/bin/ksv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM ruby
 
+# Install .ksy compiler
+RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv 379CE192D401AB61 \
+       && echo "deb https://dl.bintray.com/kaitai-io/debian jessie main" | tee /etc/apt/sources.list.d/kaitai.list \
+       && apt-get update \
+       && apt-get install kaitai-struct-compiler \
+       && rm -rf /var/lib/apt/lists/*
+
 COPY . /app
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM ruby
 
-# Install .ksy compiler
+# Install .ksy compiler and Java
 RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv 379CE192D401AB61 \
        && echo "deb https://dl.bintray.com/kaitai-io/debian jessie main" | tee /etc/apt/sources.list.d/kaitai.list \
        && apt-get update \
        && apt-get install kaitai-struct-compiler \
+       && apt-get -y install openjdk-11-jre-headless \
        && rm -rf /var/lib/apt/lists/*
 
+# Copy gem sources
 COPY . /app
 WORKDIR /app
 
+# Build and install gem
 RUN gem build -o ksv.gem kaitai-struct-visualizer \
       && gem install ksv.gem
 


### PR DESCRIPTION
I use `podman`, but the instructions should work with `docker` the same.

To build the image.
```
podman build . --tag ksv
```
To test it.
```
podman run ksv
```
To share current directory and run interactively.
```
podman run -v "$(pwd):/share":Z -w "/share" -it ksv
```
The full command I am using to inspect contents of `.snap` file using `.ksy` definition placed in current dir.
```
podman run -v "$(pwd):/share":Z -w "/share" -it ksv v3.snap squashfs_superblock.ksy
```
This generated the following output.

![image](https://user-images.githubusercontent.com/8781107/92927240-fcd59d00-f445-11ea-97af-ef29b9ebc920.png)

Should there be colors?