### PR TITLE
docker: Add automated `yes` to `apt-get` install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby
 RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv 379CE192D401AB61 \
        && echo "deb https://dl.bintray.com/kaitai-io/debian jessie main" | tee /etc/apt/sources.list.d/kaitai.list \
        && apt-get update \
-       && apt-get install kaitai-struct-compiler \
+       && apt-get -y install kaitai-struct-compiler \
        && apt-get -y install openjdk-11-jre-headless \
        && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Automated image build is stuck sometimes, because `apt-get` asks for a confirmation when multiple packages are installed. `-y` argument fixes that.