### PR TITLE
Fix building gem from git submodule

### DIFF
--- a/kaitai-struct-visualizer.gemspec
+++ b/kaitai-struct-visualizer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.require_paths = ['lib']
 
-  s.files = `git ls-files`.split("\n")
+  s.files = Dir['lib/**/*.rb'] + Dir['bin/*'] + Dir['spec/*']
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 


### PR DESCRIPTION
I got the next error when running `gem build` and repo was not a true git repo, but a relocated submodule.

    fatal: not a git repository: /share/../.git/modules/visualizer

The details are here https://github.com/rubygems/rubygems/issues/4044

The list of files produced by `git ls-files` when `git` is installed and repo is a proper clone.
```
Dockerfile
LICENSE
README.md
bin/ksdump
bin/ksv
kaitai-struct-visualizer.gemspec
lib/kaitai/console_ansi.rb
lib/kaitai/console_windows.rb
lib/kaitai/struct/visualizer.rb
lib/kaitai/struct/visualizer/hex_viewer.rb
lib/kaitai/struct/visualizer/ksy_compiler.rb
lib/kaitai/struct/visualizer/node.rb
lib/kaitai/struct/visualizer/parser.rb
lib/kaitai/struct/visualizer/tree.rb
lib/kaitai/struct/visualizer/version.rb
lib/kaitai/struct/visualizer/visualizer.rb
lib/kaitai/tui.rb
spec/ksy_compiler_spec.rb
```
I didn't include top level files as they are not used by RubyGems - https://rubygems.org/gems/kaitai-struct-visualizer