### PR TITLE
GitHub workflow to push Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,17 @@
+name: Upload Docker Image
+on:
+  push:
+    branches: [ master ]
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: docker/build-push-action@v2.2.2
+      with:
+        tags: kaitai/ksv:latest
+        push: true


### PR DESCRIPTION
I haven't tested it, because it only triggers from `master` and requires valid credentials set for `kaitai/ksv` repo, but it should work.