### PR TITLE
Use Fiddle in console-windows.rb instead of the deprecated Win32API

### DIFF
--- a/kaitai-struct-visualizer.gemspec
+++ b/kaitai-struct-visualizer.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   # s.add_development_dependency 'rspec', '~> 3'
 
   s.add_dependency 'kaitai-struct', '~> 0.4'
+  s.add_dependency 'win32-api', '~> 1.10.1'
 end

--- a/kaitai-struct-visualizer.gemspec
+++ b/kaitai-struct-visualizer.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |s|
   # s.add_development_dependency 'rspec', '~> 3'
 
   s.add_dependency 'kaitai-struct', '~> 0.4'
-  s.add_dependency 'win32-api', '~> 1.10.1'
 end

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -3,31 +3,29 @@
 require 'fiddle'
 require 'readline'
 
-include Fiddle
-
 module Kaitai
   class ConsoleWindows
     attr_reader :cols
     attr_reader :rows
 
-    kernel32 = dlopen('kernel32')
+    kernel32 = Fiddle.dlopen('kernel32')
 
-    dword = TYPE_LONG
-    word = TYPE_SHORT
-    ptr = TYPE_VOIDP
-    handle = TYPE_LONG
+    dword = Fiddle::TYPE_LONG
+    word = Fiddle::TYPE_SHORT
+    ptr = Fiddle::TYPE_VOIDP
+    handle = Fiddle::TYPE_LONG
 
-    GET_STD_HANDLE = Function.new(kernel32['GetStdHandle'], [dword], handle)
-    GET_CONSOLE_SCREEN_BUFFER_INFO = Function.new(kernel32['GetConsoleScreenBufferInfo'], [handle, ptr], dword)
+    GET_STD_HANDLE = Fiddle::Function.new(kernel32['GetStdHandle'], [dword], handle)
+    GET_CONSOLE_SCREEN_BUFFER_INFO = Fiddle::Function.new(kernel32['GetConsoleScreenBufferInfo'], [handle, ptr], dword)
 
-    FILL_CONSOLE_OUTPUT_ATTRIBUTE = Function.new(kernel32['FillConsoleOutputAttribute'], [handle, word, dword, dword, ptr], dword)
-    FILL_CONSOLE_OUTPUT_CHARACTER = Function.new(kernel32['FillConsoleOutputCharacter'], [handle, word, dword, dword, ptr], dword)
-    SET_CONSOLE_CURSOR_POSITION = Function.new(kernel32['SetConsoleCursorPosition'], [handle, dword], dword)
-    SET_CONSOLE_TEXT_ATTRIBUTE = Function.new(kernel32['SetConsoleTextAttribute'], [handle, dword], dword)
+    FILL_CONSOLE_OUTPUT_ATTRIBUTE = Fiddle::Function.new(kernel32['FillConsoleOutputAttribute'], [handle, word, dword, dword, ptr], dword)
+    FILL_CONSOLE_OUTPUT_CHARACTER = Fiddle::Function.new(kernel32['FillConsoleOutputCharacter'], [handle, word, dword, dword, ptr], dword)
+    SET_CONSOLE_CURSOR_POSITION = Fiddle::Function.new(kernel32['SetConsoleCursorPosition'], [handle, dword], dword)
+    SET_CONSOLE_TEXT_ATTRIBUTE = Fiddle::Function.new(kernel32['SetConsoleTextAttribute'], [handle, dword], dword)
 
-    WRITE_CONSOLE = Function.new(kernel32['WriteConsole'], [handle, ptr, dword, ptr, ptr], dword)
+    WRITE_CONSOLE = Fiddle::Function.new(kernel32['WriteConsole'], [handle, ptr, dword, ptr, ptr], dword)
 
-    GETCH = Function.new(dlopen('msvcrt')['_getch'], [], word)
+    GETCH = Fiddle::Function.new(dlopen('msvcrt')['_getch'], [], word)
 
     def initialize
       @stdin_handle = GET_STD_HANDLE.call(-10)

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -25,7 +25,7 @@ module Kaitai
 
     WRITE_CONSOLE = Fiddle::Function.new(kernel32['WriteConsole'], [handle, ptr, dword, ptr, ptr], dword)
 
-    GETCH = Fiddle::Function.new(dlopen('msvcrt')['_getch'], [], word)
+    GETCH = Fiddle::Function.new(Fiddle.dlopen('msvcrt')['_getch'], [], word)
 
     def initialize
       @stdin_handle = GET_STD_HANDLE.call(-10)

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -27,7 +27,7 @@ module Kaitai
 
     WRITE_CONSOLE = Function.new(kernel32['WriteConsole'], [handle, ptr, dword, ptr, ptr], dword)
 
-    GETCH = Function.new(dlopen("msvcrt")['_getch'], [], word)
+    GETCH = Function.new(dlopen('msvcrt')['_getch'], [], word)
 
     def initialize
       @stdin_handle = GET_STD_HANDLE.call(-10)

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
-require 'Win32API'
+require 'win32/api'
 require 'readline'
+
+include Win32
 
 module Kaitai
   class ConsoleWindows
     attr_reader :cols
     attr_reader :rows
 
-    GET_STD_HANDLE = Win32API.new('kernel32', 'GetStdHandle', 'L', 'L')
-    GET_CONSOLE_SCREEN_BUFFER_INFO = Win32API.new('kernel32', 'GetConsoleScreenBufferInfo', 'LP', 'L')
+    GET_STD_HANDLE = API.new('GetStdHandle', 'L', 'L', 'kernel32')
+    GET_CONSOLE_SCREEN_BUFFER_INFO = API.new('GetConsoleScreenBufferInfo', 'LP', 'L', 'kernel32')
 
-    FILL_CONSOLE_OUTPUT_ATTRIBUTE = Win32API.new('kernel32', 'FillConsoleOutputAttribute', 'LILLP', 'I')
-    FILL_CONSOLE_OUTPUT_CHARACTER = Win32API.new('kernel32', 'FillConsoleOutputCharacter', 'LILLP', 'I')
-    SET_CONSOLE_CURSOR_POSITION = Win32API.new('kernel32', 'SetConsoleCursorPosition', 'LI', 'I')
-    SET_CONSOLE_TEXT_ATTRIBUTE = Win32API.new('kernel32', 'SetConsoleTextAttribute', 'LL', 'I')
+    FILL_CONSOLE_OUTPUT_ATTRIBUTE = API.new('FillConsoleOutputAttribute', 'LILLP', 'I', 'kernel32')
+    FILL_CONSOLE_OUTPUT_CHARACTER = API.new('FillConsoleOutputCharacter', 'LILLP', 'I', 'kernel32')
+    SET_CONSOLE_CURSOR_POSITION = API.new('SetConsoleCursorPosition', 'LI', 'I', 'kernel32')
+    SET_CONSOLE_TEXT_ATTRIBUTE = API.new('SetConsoleTextAttribute', 'LL', 'I', 'kernel32')
 
-    WRITE_CONSOLE = Win32API.new('kernel32', 'WriteConsole', %w[l p l p p], 'l')
+    WRITE_CONSOLE = API.new("WriteConsole", "LPLPP", 'L', "kernel32")
 
-    GETCH = Win32API.new('msvcrt', '_getch', [], 'I')
+    GETCH = API.new("_getch", [], 'I', "msvcrt")
 
     def initialize
       @stdin_handle = GET_STD_HANDLE.call(-10)

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -13,7 +13,7 @@ module Kaitai
     dword = Fiddle::TYPE_LONG
     word = Fiddle::TYPE_SHORT
     ptr = Fiddle::TYPE_VOIDP
-    handle = Fiddle::TYPE_LONG
+    handle = Fiddle::TYPE_VOIDP
 
     GET_STD_HANDLE = Fiddle::Function.new(kernel32['GetStdHandle'], [dword], handle)
     GET_CONSOLE_SCREEN_BUFFER_INFO = Fiddle::Function.new(kernel32['GetConsoleScreenBufferInfo'], [handle, ptr], dword)

--- a/lib/kaitai/console_windows.rb
+++ b/lib/kaitai/console_windows.rb
@@ -1,26 +1,33 @@
 # frozen_string_literal: true
 
-require 'win32/api'
+require 'fiddle'
 require 'readline'
 
-include Win32
+include Fiddle
 
 module Kaitai
   class ConsoleWindows
     attr_reader :cols
     attr_reader :rows
 
-    GET_STD_HANDLE = API.new('GetStdHandle', 'L', 'L', 'kernel32')
-    GET_CONSOLE_SCREEN_BUFFER_INFO = API.new('GetConsoleScreenBufferInfo', 'LP', 'L', 'kernel32')
+    kernel32 = dlopen('kernel32')
 
-    FILL_CONSOLE_OUTPUT_ATTRIBUTE = API.new('FillConsoleOutputAttribute', 'LILLP', 'I', 'kernel32')
-    FILL_CONSOLE_OUTPUT_CHARACTER = API.new('FillConsoleOutputCharacter', 'LILLP', 'I', 'kernel32')
-    SET_CONSOLE_CURSOR_POSITION = API.new('SetConsoleCursorPosition', 'LI', 'I', 'kernel32')
-    SET_CONSOLE_TEXT_ATTRIBUTE = API.new('SetConsoleTextAttribute', 'LL', 'I', 'kernel32')
+    dword = TYPE_LONG
+    word = TYPE_SHORT
+    ptr = TYPE_VOIDP
+    handle = TYPE_LONG
 
-    WRITE_CONSOLE = API.new("WriteConsole", "LPLPP", 'L', "kernel32")
+    GET_STD_HANDLE = Function.new(kernel32['GetStdHandle'], [dword], handle)
+    GET_CONSOLE_SCREEN_BUFFER_INFO = Function.new(kernel32['GetConsoleScreenBufferInfo'], [handle, ptr], dword)
 
-    GETCH = API.new("_getch", [], 'I', "msvcrt")
+    FILL_CONSOLE_OUTPUT_ATTRIBUTE = Function.new(kernel32['FillConsoleOutputAttribute'], [handle, word, dword, dword, ptr], dword)
+    FILL_CONSOLE_OUTPUT_CHARACTER = Function.new(kernel32['FillConsoleOutputCharacter'], [handle, word, dword, dword, ptr], dword)
+    SET_CONSOLE_CURSOR_POSITION = Function.new(kernel32['SetConsoleCursorPosition'], [handle, dword], dword)
+    SET_CONSOLE_TEXT_ATTRIBUTE = Function.new(kernel32['SetConsoleTextAttribute'], [handle, dword], dword)
+
+    WRITE_CONSOLE = Function.new(kernel32['WriteConsole'], [handle, ptr, dword, ptr, ptr], dword)
+
+    GETCH = Function.new(dlopen("msvcrt")['_getch'], [], word)
 
     def initialize
       @stdin_handle = GET_STD_HANDLE.call(-10)


### PR DESCRIPTION
Win32API, which was originally part of the Ruby standard library, was [slated for removal in version 2.0](https://www.rubydoc.info/gems/win32-api/1.10.1), according to the developer of win32-api. win32-api is a `drop-in replacement for the Win32API library`. The only major differences are putting the dll name as the last argument, and it requires capital letters for prototype and return types.

The developer states that:
```
As of win32-api 1.4.8 a binary gem is shipped that contains binaries for both Ruby 1.8, Ruby 1.9, and 2.x.
For Ruby 2.x, both 32 and 64 bit binaries are included as of release 1.5.0.
The file under lib/win32 dynamically requires the correct binary based on your version of Ruby.
```
So, there is not a problem supporting multiple versions of Ruby with this change.

I have tested this on Ruby 3.0.2 on Windows 10.0.19043 in Command Prompt and Powershell v5.1.19041.1237