### PR TITLE
Show Ruby runtime lib version in `{ksv,ksdump} --version`

### DIFF
--- a/bin/ksdump
+++ b/bin/ksdump
@@ -33,12 +33,14 @@ parser = OptionParser.new do |opts|
     options[:format] = v
   end
 
-  opts.on('--version', "show versions of #{prog_name} and ksc") do |_v|
+  opts.on('--version', "show versions of #{prog_name}, ksc and kaitai-struct (Kaitai Struct runtime library for Ruby)") do |_v|
     puts "#{prog_name} #{Kaitai::Struct::Visualizer::VERSION}"
     if system('kaitai-struct-compiler', '--version').nil?
       $stderr.puts 'ksv: unable to find and run kaitai-struct-compiler in your PATH'
       exit 1
     end
+    require 'kaitai/struct/struct'
+    puts "kaitai-struct #{Kaitai::Struct::VERSION} (Kaitai Struct runtime library for Ruby)"
     exit 0
   end
 end

--- a/bin/ksv
+++ b/bin/ksv
@@ -34,12 +34,14 @@ parser = OptionParser.new do |opts|
     require v
   end
 
-  opts.on('--version', 'show versions of ksv and ksc') do |_v|
+  opts.on('--version', 'show versions of ksv, ksc and kaitai-struct (Kaitai Struct runtime library for Ruby)') do |_v|
     puts "kaitai-struct-visualizer #{Kaitai::Struct::Visualizer::VERSION}"
     if system('kaitai-struct-compiler', '--version').nil?
       $stderr.puts 'ksv: unable to find and run kaitai-struct-compiler in your PATH'
       exit 1
     end
+    require 'kaitai/struct/struct'
+    puts "kaitai-struct #{Kaitai::Struct::VERSION} (Kaitai Struct runtime library for Ruby)"
     exit 0
   end
 end


### PR DESCRIPTION
I think this would be a nice improvement because the user is supposed to keep the versions of `kaitai-struct-compiler` and the Ruby runtime compatible, but so far the `--version` doesn't indicate which version of the Ruby runtime library is being used.

I'm not sure what exactly should the output of `--help` and `--version` look like so that it's clear to everyone but perhaps isn't too verbose - so I'd like to discuss it here. I thought it'd be a good idea to include the name of the gem [at RubyGems](https://rubygems.org/gems/kaitai-struct) (i.e. `kaitai-struct`), but I feel like if I don't explain `kaitai-struct` in any way, the user wouldn't know what it is.